### PR TITLE
Add the method on the pre create filter condition event

### DIFF
--- a/Query/FilterConditionFactory.php
+++ b/Query/FilterConditionFactory.php
@@ -37,7 +37,7 @@ class FilterConditionFactory
      */
     public function create(Field $field, $method, $value)
     {
-        $event = new PreCreateFilterConditionEvent($field->getDataType(), $value);
+        $event = new PreCreateFilterConditionEvent($field->getDataType(), $value, $method);
         $this->eventDispatcher->dispatch(
             InterpreterEvents::PRE_CREATE_FILTER_CONDITION,
             $event

--- a/UQL/Event/PreCreateFilterConditionEvent.php
+++ b/UQL/Event/PreCreateFilterConditionEvent.php
@@ -17,13 +17,20 @@ class PreCreateFilterConditionEvent extends Event
     private $databaseValue;
 
     /**
-     * @param DataTypeInterface $dataType
-     * @param mixed $value
+     * @var string
      */
-    public function __construct(DataTypeInterface $dataType, $value)
+    private $method;
+
+    /**
+     * @param DataTypeInterface $dataType
+     * @param mixed             $value
+     * @param string            $method
+     */
+    public function __construct(DataTypeInterface $dataType, $value, $method)
     {
         $this->dataType = $dataType;
         $this->databaseValue = $value;
+        $this->method = $method;
     }
 
     /**
@@ -48,5 +55,13 @@ class PreCreateFilterConditionEvent extends Event
     public function setDatabaseValue($databaseValue)
     {
         $this->databaseValue = $databaseValue;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
     }
 }


### PR DESCRIPTION
Pre create filter condition event is used to convert the values that user has put in uql

The reason I added this 'method' parameter on the pre create filter condition event, is because we want based on the method not to allow the values to be converted. 

E.g. we should never try to convert values when we use the 'IN' method