### PR TITLE
Function not found exception extends UQLException

### DIFF
--- a/Extension/Exception/FunctionNotFoundException.php
+++ b/Extension/Exception/FunctionNotFoundException.php
@@ -2,6 +2,8 @@
 
 namespace Netdudes\DataSourceryBundle\Extension\Exception;
 
-class FunctionNotFoundException extends \Exception
+use Netdudes\DataSourceryBundle\UQL\Exception\UQLException;
+
+class FunctionNotFoundException extends UQLException
 {
 }


### PR DESCRIPTION
So the problem here is that when we use a function that does not exist, we throw a `FunctionNotFoundException`, which extends the `Exception`.

*But* we only handle `UQLException`. You can check:
* src/TableBundle/Table/Table.php:88
* src/TableBundle/Controller/Traits/UqlControllerTrait.php:52

The funny thing is that our `ErrorHandler` handles both `UQLException` and `Exception`.
You can check:
* src/CoreBundle/Table/ErrorHandler.php:40

So there are 2 ways to solve this problem. Either the `FunctionNotFoundException` extends the `UQLExtension` or we handle `Exception` instead of `UQLException` on the classes:
* src/TableBundle/Table/Table.php
* src/TableBundle/Controller/Traits/UqlControllerTrait.php

The result of the first implementation that I preferred is:

![screen shot 2016-10-26 at 16 01 39](https://cloud.githubusercontent.com/assets/12499205/19729056/ecf22fa0-9b95-11e6-88d2-d423ffe8890b.png)

The resulf of the second implementation is:

![screen shot 2016-10-26 at 16 02 17](https://cloud.githubusercontent.com/assets/12499205/19729063/f6469956-9b95-11e6-9103-35d1d51e4f93.png)
