### PR TITLE
Required fields extractor returns all selected fields

### DIFF
--- a/DataSource/Driver/Doctrine/QueryBuilder/RequiredFieldsExtractor.php
+++ b/DataSource/Driver/Doctrine/QueryBuilder/RequiredFieldsExtractor.php
@@ -80,7 +80,7 @@ class RequiredFieldsExtractor
         $dependantFields = [];
         foreach ($fieldNames as $fieldName) {
             $field = $this->getField($fieldName);
-            if ($field && is_array($field->getDatabaseSelectAlias())) {
+            if ($field !== null && is_array($field->getDatabaseSelectAlias())) {
                 foreach ($field->getDatabaseSelectAlias() as $secondLevelRequiredField) {
                     $dependantFields[] = $secondLevelRequiredField;
                 }

--- a/DataSource/Driver/Doctrine/QueryBuilder/RequiredFieldsExtractor.php
+++ b/DataSource/Driver/Doctrine/QueryBuilder/RequiredFieldsExtractor.php
@@ -80,16 +80,7 @@ class RequiredFieldsExtractor
         $dependantFields = [];
         foreach ($fieldNames as $fieldName) {
             $field = $this->getField($fieldName);
-            if (!$field) {
-                $allFieldNames = array_map(
-                    function (Field $field) {
-                        return $field->getUniqueName();
-                    },
-                    $this->queryBuilderDataSourceFields
-                );
-                throw new \Exception("Field unique name '$fieldName' not in list of fields: " . implode(', ', $allFieldNames));
-            }
-            if (is_array($field->getDatabaseSelectAlias())) {
+            if ($field && is_array($field->getDatabaseSelectAlias())) {
                 foreach ($field->getDatabaseSelectAlias() as $secondLevelRequiredField) {
                     $dependantFields[] = $secondLevelRequiredField;
                 }

--- a/Tests/DataSource/Driver/Doctrine/QueryBuilder/RequiredFieldsExtractorTest.php
+++ b/Tests/DataSource/Driver/Doctrine/QueryBuilder/RequiredFieldsExtractorTest.php
@@ -23,7 +23,7 @@ class RequiredFieldsExtractorTest extends \PHPUnit_Framework_TestCase
 
         $requiredFields = $extractor->extractRequiredFields($query);
 
-        $this->assertCount(7, $requiredFields);
+        $this->assertCount(8, $requiredFields);
         $this->assertContains('TEST_FIELD_1_REQUIRED_BY_COMPLEX', $requiredFields);
         $this->assertContains('TEST_FIELD_2_REQUIRED_BY_COMPLEX', $requiredFields);
         $this->assertContains('TEST_FIELD_3_THAT_IS_COMPLEX', $requiredFields);
@@ -32,6 +32,7 @@ class RequiredFieldsExtractorTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('TEST_FIELD_6_REQUIRED_BY_FILTER', $requiredFields);
         $this->assertContains('TEST_FIELD_7_REQUIRED_BY_SORT', $requiredFields);
         $this->assertNotContains('TEST_FIELD_8_NOT_REQUIRED', $requiredFields);
+        $this->assertContains('UNSUPPORTED_FIELD', $requiredFields);
     }
 
     /**
@@ -76,7 +77,7 @@ class RequiredFieldsExtractorTest extends \PHPUnit_Framework_TestCase
         $query = new Query();
         $query->setFilter($filter);
         $query->setSort($sort);
-        $query->setSelect(['TEST_FIELD_4_REQUIRED_BY_SELECT', 'TEST_FIELD_3_THAT_IS_COMPLEX']);
+        $query->setSelect(['TEST_FIELD_4_REQUIRED_BY_SELECT', 'TEST_FIELD_3_THAT_IS_COMPLEX', 'UNSUPPORTED_FIELD']);
 
         return $query;
     }


### PR DESCRIPTION
This change means that extracted required fields that are returned from `Query.php` are not validated.

You can check:
- Query/Query.php:99